### PR TITLE
Allow multiple configure blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,22 @@ TimePilot.configure do |c|
 end
 ```
 
+## Multiple configure blocks
+
+TimePilot allows you to specify more than one configure block. This allows you to specify features at multiple levels. For example, you could specify features in a Rails Engine located in a separate gem, as well as the host application. It's easy as this:
+
+```ruby
+# vendor/gems/.../config/initializers/time_pilot.rb
+TimePilot.configure do |c|
+  c.feature :this_could_be_my_rails_engine
+end
+
+# config/initializers/time_pilot.rb
+TimePilot.configure do |c|
+  c.feature :this_is_my_host_application
+end
+```
+
 TimePilot assumes you put in an object that responds to `#sadd`, `#srem` and `#sismember`.
 
 # Usage

--- a/lib/time_pilot/time_pilot.rb
+++ b/lib/time_pilot/time_pilot.rb
@@ -2,7 +2,7 @@ module TimePilot
   NAMESPACE = 'timepilot'
 
   def self.configure
-    @config = Configuration.new
+    @config ||= Configuration.new
     yield @config
     @config.features.each do |feature_name|
       Features.module_eval do

--- a/test/time_pilot_test.rb
+++ b/test/time_pilot_test.rb
@@ -35,6 +35,10 @@ TimePilot.configure do |c|
   c.feature 'planning'
 end
 
+TimePilot.configure do |c|
+  c.feature 'secret_feature'
+end
+
 describe TimePilot do
   before do
     TimePilot.redis.flushdb
@@ -44,6 +48,12 @@ describe TimePilot do
     @retail = Team.new(@nedap.id, 12)
     @john = Employee.new(@nedap.id, @healthcare.id, 21)
     @jane = Employee.new(@nedap.id, @healthcare.id, 22)
+  end
+
+  it 'allows multiple configure blocks to add features' do
+    TimePilot.features.must_equal ['planning', 'secret_feature']
+    @acme.planning_enabled?.must_equal false
+    @acme.secret_feature_enabled?.must_equal false
   end
 
   it 'defines a getter on company' do


### PR DESCRIPTION
This would help support a more layered approach like when we enable time_pilot in a Rails engine for several features and allow the app builder to add more.

```ruby
TimePilot.configure do |c|
  c.feature 'planning'
end

TimePilot.configure do |c|
  c.feature 'secret_feature'
end
```