### PR TITLE
Reduces the calls to redis for consecutive checks

### DIFF
--- a/lib/time_pilot/time_pilot.rb
+++ b/lib/time_pilot/time_pilot.rb
@@ -70,15 +70,15 @@ module TimePilot
     end
 
     def pilot_enable_feature(feature_name)
-      instance_variable_set("@#{feature_name}_enabled", true)
       key_name = "#{feature_name}:#{self.class.to_s.underscore}_ids"
       TimePilot.redis.sadd TimePilot.key(key_name), id
+      instance_variable_set("@#{feature_name}_enabled", true)
     end
 
     def pilot_disable_feature(feature_name)
-      instance_variable_set("@#{feature_name}_enabled", false)
       key_name = "#{feature_name}:#{self.class.to_s.underscore}_ids"
       TimePilot.redis.srem TimePilot.key(key_name), id
+      instance_variable_set("@#{feature_name}_enabled", false)
     end
 
     def pilot_feature_enabled?(feature_name)

--- a/test/time_pilot_test.rb
+++ b/test/time_pilot_test.rb
@@ -59,6 +59,7 @@ describe TimePilot do
   it 'defines a getter on company' do
     TimePilot.redis.sadd 'timepilot:planning:company_ids', @acme.id
     @acme.planning_enabled?.must_equal true
+    @acme.planning_enabled.must_equal true
   end
 
   it 'defines an enabler on company' do
@@ -69,8 +70,10 @@ describe TimePilot do
   it 'defines a disabler on employee' do
     @nedap.enable_planning
     @nedap.planning_enabled?.must_equal true
+    @nedap.planning_enabled.must_equal true
     @nedap.disable_planning
     @nedap.planning_enabled?.must_equal false
+    @nedap.planning_enabled.must_equal false
   end
 
   it 'defines a getter on team' do
@@ -86,13 +89,16 @@ describe TimePilot do
   it 'defines a disabler on team' do
     @retail.enable_planning
     @retail.planning_enabled?.must_equal true
+    @retail.planning_enabled.must_equal true
     @retail.disable_planning
     @retail.planning_enabled?.must_equal false
+    @retail.planning_enabled.must_equal false
   end
 
   it 'defines a getter on employee' do
     TimePilot.redis.sadd 'timepilot:planning:employee_ids', @john.id
     @john.planning_enabled?.must_equal true
+    @john.planning_enabled.must_equal true
   end
 
   it 'defines an enabler on employee' do
@@ -103,8 +109,10 @@ describe TimePilot do
   it 'defines a disabler on employee' do
     @jane.enable_planning
     @jane.planning_enabled?.must_equal true
+    @jane.planning_enabled.must_equal true
     @jane.disable_planning
     @jane.planning_enabled?.must_equal false
+    @jane.planning_enabled.must_equal false
   end
 
   it 'defines a cardinality count on the classes' do
@@ -125,16 +133,19 @@ describe TimePilot do
   specify 'company overrides team' do
     @nedap.enable_planning
     @retail.planning_enabled?.must_equal true
+    @retail.planning_enabled.must_equal true
   end
 
   specify 'team overrides employee' do
     @healthcare.enable_planning
     @john.planning_enabled?.must_equal true
+    @john.planning_enabled.must_equal true
   end
 
   specify 'company overrides employee' do
     @nedap.enable_planning
     @jane.planning_enabled?.must_equal true
+    @jane.planning_enabled.must_equal true
   end
 end
 
@@ -146,5 +157,14 @@ end
 describe TimePilot, 'converting CamelCase to camel_case' do
   it do
     CamelCasedModel.time_pilot_groups.must_equal ['camel_cased_model']
+  end
+end
+
+describe TimePilot, 'reduce redis load' do
+  it 'calls redis only once' do
+    TimePilot.redis.expect(:sismember, true, ['timepilot:planning:company_ids', @acme.id])
+
+    @acme.planning_enabled?.must_equal true
+    @acme.planning_enabled?.must_equal true
   end
 end


### PR DESCRIPTION
With some time pilot features it can happen that the check it executed several times in one request as they can cause response spikes in production. To reduce the load of these call we cache the response as an instance variable.

```
web    | [nedap] [2c12af60-ecf7-4448-b84c-559e8c0ef9da] [dkxrODE5ZXZ5WGNr]   Redis (0.36ms)  [ SISMEMBER timepilot:send_check_events:healthcare_multi_tenant/care_provider_ids 1 ]
web    | [nedap] [2c12af60-ecf7-4448-b84c-559e8c0ef9da] [dkxrODE5ZXZ5WGNr]   Redis (0.15ms)  [ SISMEMBER timepilot:send_check_events:healthcare_multi_tenant/care_provider_ids 1 ]
web    | [nedap] [2c12af60-ecf7-4448-b84c-559e8c0ef9da] [dkxrODE5ZXZ5WGNr]   Redis (0.19ms)  [ SISMEMBER timepilot:send_check_events:healthcare_multi_tenant/care_provider_ids 1 ]
web    | [nedap] [2c12af60-ecf7-4448-b84c-559e8c0ef9da] [dkxrODE5ZXZ5WGNr]   Redis (0.15ms)  [ SISMEMBER timepilot:send_check_events:healthcare_multi_tenant/care_provider_ids 1 ]
web    | [nedap] [2c12af60-ecf7-4448-b84c-559e8c0ef9da] [dkxrODE5ZXZ5WGNr]   Redis (0.56ms)  [ SISMEMBER timepilot:send_check_events:healthcare_multi_tenant/care_provider_ids 1 ]
```

<img width="555" alt="screen shot 2018-07-25 at 10 02 22" src="https://user-images.githubusercontent.com/504708/43187521-e3ac4bae-8ff1-11e8-9c7e-9a16584efc37.png">
