### PR TITLE
fix: Fix pipeline deprecation in redis-rb 4.6

### DIFF
--- a/lib/time_pilot/time_pilot.rb
+++ b/lib/time_pilot/time_pilot.rb
@@ -90,9 +90,9 @@ module TimePilot
     end
 
     def pilot_member_in_any_group?(feature_name)
-      TimePilot.redis.pipelined do
+      TimePilot.redis.pipelined do |pipeline|
         self.class.time_pilot_groups.each do |group|
-          TimePilot.redis.sismember(
+          pipeline.sismember(
             TimePilot.key("#{feature_name}:#{group}_ids"),
             send(pilot_method_for_group(group))
           )


### PR DESCRIPTION
Calling commands on Redis inside pipelined is deprecated, see https://github.com/redis/redis-rb/blob/13c7a8e4fdb23d0fde8534ea974fdf089c8d11bc/CHANGELOG.md#460