### PR TITLE
use sadd? instead of sadd

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source "http://rubygems.org"
 gem 'rake'
-gem 'redis'
+gem 'redis', '>= 4.8.0'
 gemspec

--- a/lib/time_pilot/time_pilot.rb
+++ b/lib/time_pilot/time_pilot.rb
@@ -77,7 +77,7 @@ module TimePilot
 
     def pilot_disable_feature(feature_name)
       key_name = "#{feature_name}:#{self.class.to_s.underscore}_ids"
-      TimePilot.redis.srem TimePilot.key(key_name), id
+      TimePilot.redis.srem? TimePilot.key(key_name), id
       instance_variable_set("@#{feature_name}_enabled", false)
     end
 

--- a/lib/time_pilot/time_pilot.rb
+++ b/lib/time_pilot/time_pilot.rb
@@ -71,7 +71,7 @@ module TimePilot
 
     def pilot_enable_feature(feature_name)
       key_name = "#{feature_name}:#{self.class.to_s.underscore}_ids"
-      TimePilot.redis.sadd TimePilot.key(key_name), id
+      TimePilot.redis.sadd? TimePilot.key(key_name), id
       instance_variable_set("@#{feature_name}_enabled", true)
     end
 

--- a/test/time_pilot_test.rb
+++ b/test/time_pilot_test.rb
@@ -62,7 +62,7 @@ describe TimePilot do
   end
 
   it "defines a getter on company" do
-    TimePilot.redis.sadd "timepilot:planning:company_ids", @acme.id
+    TimePilot.redis.sadd? "timepilot:planning:company_ids", @acme.id
     _(@acme.planning_enabled?).must_equal true
     _(@acme.instance_variable_get("@planning_enabled")).must_equal true
   end
@@ -82,7 +82,7 @@ describe TimePilot do
   end
 
   it "defines a getter on team" do
-    TimePilot.redis.sadd "timepilot:planning:team_ids", @healthcare.id
+    TimePilot.redis.sadd? "timepilot:planning:team_ids", @healthcare.id
     _(@healthcare.planning_enabled?).must_equal true
   end
 
@@ -101,7 +101,7 @@ describe TimePilot do
   end
 
   it "defines a getter on employee" do
-    TimePilot.redis.sadd "timepilot:planning:employee_ids", @john.id
+    TimePilot.redis.sadd? "timepilot:planning:employee_ids", @john.id
     _(@john.planning_enabled?).must_equal true
     _(@john.instance_variable_get("@planning_enabled")).must_equal true
   end
@@ -192,7 +192,7 @@ describe TimePilot do
   end
 
   specify "does not call redis to get status after disabling" do
-    @mock.expect(:srem, true, ["timepilot:planning:company_ids", @acme.id])
+    @mock.expect(:srem?, true, ["timepilot:planning:company_ids", @acme.id])
 
     @acme.disable_planning
     # Call the feature again it should hit the instance variable
@@ -202,7 +202,7 @@ describe TimePilot do
   end
 
   specify "does not call redis to get status after enabling" do
-    @mock.expect(:sadd, true, ["timepilot:planning:company_ids", @acme.id])
+    @mock.expect(:sadd?, true, ["timepilot:planning:company_ids", @acme.id])
 
     @acme.enable_planning
     # Call the feature again it should hit the instance variable

--- a/time_pilot.gemspec
+++ b/time_pilot.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.email       = ['matthijs.langenberg@nedap.com', 'mark.oudeveldhuis@nedap.com']
   s.homepage    = 'https://github.com/nedap/time_pilot'
 
-  s.add_dependency 'redis', '>= 3.0.0'
+  s.add_dependency 'redis', '>= 4.8.0'
   s.add_dependency 'activesupport', '>= 3.0.0'
   s.add_development_dependency "minitest"
 end


### PR DESCRIPTION
Currently whenever time_pilot is used in a project with Redis 5+ it will log the following deprecation warning:

```
Redis#sadd will always return an Integer in Redis 5.0.0. Use Redis#sadd? instead.(called from: /home/bob.vanderlinden/.gem/ruby/2.7.0/gems/time_pilot-1.0.1/lib/time_pilot/time_pilot.rb:74:in `pilot_enable_feature')
```

This PR is an attempt to follow up with that suggestion.